### PR TITLE
Expanding well-defined repo with a PATH dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ gem "json-schema", git: "https://github.com/3scale/json-schema"
 
 gem "nokogiri", "~> 1.16"
 
+gem "quux", path: "./quux"
+
 source "http://rubygems.org" do
   gem "mygem"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,11 @@ PATH
   specs:
     tmp (0.1.2)
 
+PATH
+  remote: quux
+  specs:
+    quux (0.0.1)
+
 GEM
   remote: http://rubygems.org/
   specs:
@@ -184,8 +189,9 @@ DEPENDENCIES
   json-schema!
   mygem!
   nokogiri (~> 1.16)
+  quux!
   rails (= 6.1.7)
   tmp!
 
 BUNDLED WITH
-   2.5.16
+   2.5.11

--- a/quux/Gemfile
+++ b/quux/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# gem "rails"

--- a/quux/Gemfile.lock
+++ b/quux/Gemfile.lock
@@ -1,0 +1,12 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+
+BUNDLED WITH
+   2.5.11

--- a/quux/quux.gemspec
+++ b/quux/quux.gemspec
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+  spec.name = "quux"
+  spec.version = "0.0.1"
+  spec.authors = ["Alexey Ovchinnikov"]
+  spec.email = ["aovchinn@redhat.com"]
+  spec.summary = "A minimal dummy gem."
+end


### PR DESCRIPTION
Previously there was no proper PATH dependency. This change introduces a dummy nested dependency.

Addresses [Issue No. 1](https://github.com/cachito-testing/cachi2-testing/issues/1).